### PR TITLE
Update mapz-driver cmakelists.txt for GCC

### DIFF
--- a/model/mapz-driver/CMakeLists.txt
+++ b/model/mapz-driver/CMakeLists.txt
@@ -35,5 +35,5 @@ ecbuild_add_executable(
   SOURCES ${srcs}
   LIBS ${FMS} ${MAPL_BASE})
 target_compile_definitions(mapz-driver PRIVATE MAPL_MODE SPMD TIMING)
-target_compile_options(mapz-driver PRIVATE -traceback)
+target_compile_options(mapz-driver PRIVATE ${TRACEBACK})
 set_target_properties(${this} PROPERTIES Fortran_MODULE_DIRECTORY ${esma_include}/${this})


### PR DESCRIPTION
The mapz-driver used `-traceback` which is an Intel-only flag. Use the agnostic `${TRACEBACK}` option instead.