### PR TITLE
Updates to allow for building FV dynamics as non-hydrostatic

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -85,6 +85,15 @@ endif()
 
 target_compile_definitions (${this} PRIVATE MAPL_MODE SPMD TIMING)
 
+option(HYDROSTATIC "Build FV dynamics as hydrostatic" ON)
+if (HYDROSTATIC)
+   ecbuild_info("Building FV dynamics as hydrostatic")
+else()
+   ecbuild_info("Building FV dynamics as non-hydrostatic")
+   ecbuild_info("This sets MOIST_CAPPA and USE_COND preprocessor variables")
+   target_compile_definitions (${this} PRIVATE MOIST_CAPPA USE_COND)
+endif ()
+
 esma_add_subdirectories(
   model/mapz-driver
   model/tp-core-driver)


### PR DESCRIPTION
This pull request adds a new CMake build option to GEOS. By default, it will build with `-DHYDROSTATIC=ON` meaning "built for hydrostatic dynamics". If you build with `-DHYDROSTATIC=OFF` then "built for non-hydrostatic dynamics" which implies setting the `MOIST_CAPPA` and `USE_COND` preprocessor variables in fvdycore.