### PR TITLE
Fix typos in upper air regridding code.

### DIFF
--- a/tools/init_hydro.F90
+++ b/tools/init_hydro.F90
@@ -79,7 +79,12 @@ contains
  subroutine p_var(km, ifirst, ilast, jfirst, jlast, ptop, ptop_min,    &
                   delp, delz, pt, ps,  pe, peln, pk, pkz, cappa, q, ng, nq, area,   &
                   dry_mass, adjust_dry_mass, mountain, moist_phys,      &
-                  hydrostatic, nwat, domain, make_nh)
+                  hydrostatic, nwat, domain, make_nh &
+#ifdef MAPL_MODE
+                  ,do_pkz)
+#else
+                  )
+#endif
 ! Given (ptop, delp) computes (ps, pk, pe, peln, pkz)
 ! Input:
    integer,  intent(in):: km
@@ -95,6 +100,9 @@ contains
    real, intent(inout)::    q(ifirst-ng:ilast+ng,jfirst-ng:jlast+ng, km, nq)
    real(kind=R_GRID), intent(IN)   :: area(ifirst-ng:ilast+ng,jfirst-ng:jlast+ng)
    logical, optional:: make_nh
+#ifdef MAPL_MODE
+   logical, intent(in), optional :: do_pkz
+#endif
 ! Output:
    real, intent(out) ::   ps(ifirst-ng:ilast+ng, jfirst-ng:jlast+ng)
    real, intent(out) ::   pk(ifirst:ilast, jfirst:jlast, km+1)
@@ -191,6 +199,9 @@ contains
           endif
       endif
 
+#ifdef MAPL_MODE
+     if (do_pkz) then
+#endif
      if ( moist_phys ) then
 !------------------------------------------------------------------
 ! The following form is the same as in "fv_update_phys.F90"
@@ -222,6 +233,9 @@ contains
           enddo
        enddo
      endif
+#ifdef MAPL_MODE
+     end if
+#endif
 
    endif
 


### PR DESCRIPTION
While testing regrid.pl and having built the model with the debug options I noticed that interp_restarts was crashing. On examination I found a typo that had been replicated, probably due to copying and pasting code. The typo was that what should have been an ie_i was ie+1 like in the following block of code:
```
u0(is_i:ie_i,js_i:je_i,k) = gslice_r8(is_i:ie+i,tileoff+js_i:tileoff+je_i)
```
Note these variables were the upper bound for the local processor in the first dimension and ie_i is for the input grid and ie was for the output grid. Finally i is used in a loop before this and loops from ie to is+1.
I've tested now going from c24 -> c48 and c360 -> c90 and I'm getting the same result in the fixed code on the branch and the stock code with the typo. I'm not sure how to explain this as at least in the c360 -> c90 case would result in not enough data getting copied to the left hand side of the expression. However, I even tried making a new variable (u0p in the code below) and comparison when filling it with the right vs wrong expression and the check that the arrays were equal did not report any different values!
```
! Read U
         allocate (  u0(isd_i:ied_i,jsd_i:jed_i+1,km) )
         u0(:,:,:) = 0.0
         allocate (  u0p(isd_i:ied_i,jsd_i:jed_i+1,km) )
         u0(:,:,:) = 0.0
         u0p(:,:,:) = 0.0
         if (isNC4) then
            tileoff = (tile-1)*(jm/ntiles)
               write(*,*)"bmaa ", maxval(u0),ie_i,ie+i
            do k=1,km
               call MAPL_VarRead(formatter,"U",gslice_r8,lev=k)
               u0(is_i:ie_i,js_i:je_i,k) = gslice_r8(is_i:ie+i,tileoff+js_i:tileoff+je_i)
               u0p(is_i:ie_i,js_i:je_i,k) = gslice_r8(is_i:ie_i,tileoff+js_i:tileoff+je_i)
            enddo
            if (any(u0/=u0p)) then
               write(*,*)"FOUND DIFF"
            end if
```
So at this point I don't know what to say other than despite the typo it seems like it by accident copies the correct memory into the left hand side.

In addition in fv_regrid_c3c.F90 after regridding to the output grid, a call to p_var is made in get_geos_ic that causes the code to crash when debugging is on when trying to fill pkz. In interp_restarts.F90 after leaving get_geos_ic, we immediately fill pkz anyway so it just gets overwritten. So I added a flag to skip the pkz calculation at the end of p_var so the code will run with debugging on. I've confirmed whether or not you execute the code in p_var that causes the code to crash in debugging mode seems to have no difference in results when running with optimization.
