### PR TITLE
Updates for Spack Support, Round 2

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -45,17 +45,9 @@ set (srcs
   model/fv_nesting.F90
   )
 
-if (ESMA_USE_GFE_NAMESPACE)
-   esma_add_library (${this}
-      SRCS ${srcs}
-      DEPENDENCIES MAPL GFTL_SHARED::gftl-shared
-      INCLUDES ${INC_ESMF})
-else ()
-   esma_add_library (${this}
-      SRCS ${srcs}
-      DEPENDENCIES MAPL gftl-shared
-      INCLUDES ${INC_ESMF})
-endif ()
+esma_add_library (${this}
+  SRCS ${srcs}
+  DEPENDENCIES MAPL GFTL_SHARED::gftl-shared esmf)
 
 if (FV_PRECISION STREQUAL R4)
 elseif (FV_PRECISION STREQUAL R4R8) # FV is R4 but FMS is R8


### PR DESCRIPTION
Due to insufficient grepping on my part, some remnants of the
"non-canonical" CMake still remain. Apparently these were not necessary
changes for Spack, but they are changes that unify the CMake style of
GEOS to be more like "correct" CMake.

In this go-around, it is mainly finding `INC_ESMF` which I apparently
forgot to grep for last time (I was focused on NetCDF), and some
non-canonical OpenMP calls.

See https://github.com/GEOS-ESM/GEOSgcm/issues/387 for the meta-issue.