### PR TITLE
Update fvdycore for FMS updates (no hardcoded input nml path)

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -87,6 +87,9 @@ ecbuild_info("Building FV dynamics dual hydrostatic/non-hydrostatic")
 ecbuild_info("This sets MOIST_CAPPA and USE_COND preprocessor variables")
 target_compile_definitions (${this} PRIVATE MOIST_CAPPA USE_COND)
 
+ecbuild_info("This sets the INTERNAL_FILE_NML preprocessor variable")
+target_compile_definitions (${this} PRIVATE INTERNAL_FILE_NML)
+
 esma_add_subdirectories(
   model/mapz-driver
   model/tp-core-driver)

--- a/model/fv_control.F90
+++ b/model/fv_control.F90
@@ -729,8 +729,10 @@ module fv_control_mod
       read (input_nml_file,test_case_nml,iostat=ios)
       ierr = check_nml_error(ios,'test_case_nml')
 
-   ! Reset input_file_nml to default behavior
-      call read_input_nml
+   ! Reset input_file_nml to default behavior if necessary
+      if (n > 1) then
+        call read_input_nml
+      endif
 #else
       if (size(Atm) == 1) then
          f_unit = open_namelist_file()
@@ -750,7 +752,7 @@ module fv_control_mod
       read (f_unit,test_case_nml,iostat=ios)
       ierr = check_nml_error(ios,'test_case_nml')
       call close_file(f_unit)
-#endif         
+#endif
       write(unit, nml=fv_core_nml)
       write(unit, nml=test_case_nml)
 

--- a/model/fv_control.F90
+++ b/model/fv_control.F90
@@ -89,7 +89,7 @@ module fv_control_mod
 !     <td>mpp_send, mpp_sync, mpp_transmit, mpp_set_current_pelist, mpp_declare_pelist, 
 !         mpp_root_pe, mpp_recv, mpp_sync_self, mpp_broadcast, read_input_nml,
 !         FATAL, mpp_error, mpp_pe, stdlog, mpp_npes, mpp_get_current_pelist, 
-!         input_nml_file, get_unit, WARNING, read_ascii_file, INPUT_STR_LENGTH</td>
+!         input_nml_file, get_unit, WARNING, read_ascii_file</td>
 !   </tr>
 !   <tr>
 !     <td>mpp_domains_mod</td>
@@ -121,7 +121,7 @@ module fv_control_mod
    use mpp_mod,             only: FATAL, mpp_error, mpp_pe, stdlog, &
                                   mpp_npes, mpp_get_current_pelist, &
                                   input_nml_file, get_unit, WARNING, &
-                                  read_ascii_file, INPUT_STR_LENGTH
+                                  read_ascii_file
    use mpp_domains_mod,     only: mpp_get_data_domain, mpp_get_compute_domain
    use tracer_manager_mod,  only: tm_get_number_tracers => get_number_tracers, &
                                   tm_get_tracer_index   => get_tracer_index,   &

--- a/model/lin_cloud_microphys.F90
+++ b/model/lin_cloud_microphys.F90
@@ -36,7 +36,7 @@
 
 module gfdl_lin_cloud_microphys_mod
     
-      use mpp_mod, only: mpp_pe, mpp_root_pe
+      use mpp_mod, only: mpp_pe, mpp_root_pe, input_nml_file
     ! use mpp_mod, only: stdlog, mpp_pe, mpp_root_pe, mpp_clock_id, &
     ! mpp_clock_begin, mpp_clock_end, clock_routine, &
     ! input_nml_file


### PR DESCRIPTION
This PR needs to go with https://github.com/GEOS-ESM/FMS/pull/29

It turns out that the FV dycore branch used by GEOS only works - in JEDI - with those FMS changes. @cmgas ran a GEOS-GCM standalone forecast with the dycore changes here and the FMS changes in the PR above, and it ran w/o errors (i.e. it passed the smoke test).