### PR TITLE
WIP: Fix for GCC 14. Always allocate NH arrays

### DIFF
--- a/model/fv_arrays.F90
+++ b/model/fv_arrays.F90
@@ -1498,21 +1498,21 @@ contains
     !--------------------------
     ! Non-hydrostatic dynamics:
     !--------------------------
-    if ( Atm%flagstruct%hydrostatic ) then
-       !Note length-one initialization if hydrostatic = .true.
-       allocate (    Atm%w(isd:isd, jsd:jsd  ,1) )
-       allocate ( Atm%delz(isd:isd, jsd:jsd  ,1) )
-       allocate (  Atm%ze0(is:is, js:js  ,1) )
+    ! Note: GCC 14 found that the call to c_sw in has a loop over
+    !       the third dimension of Atm%w from 1 to npz. But if
+    !       hydrostatic, this below allocated as (1,1,1). GCC 14
+    !       debugging flags triggered on this when k=2. So, as a
+    !       mitigation, we just allocate all these arrays like
+    !       it was non-hydrostatic. This is a bit wasteful, but
+    !       it is a simple fix.
+    allocate (    Atm%w(isd:ied, jsd:jed  ,npz  ) )
+    allocate ( Atm%delz(isd:ied, jsd:jed  ,npz) )
+    if( Atm%flagstruct%hybrid_z ) then
+       allocate (  Atm%ze0(is:ie, js:je ,npz+1) )
     else
-       allocate (    Atm%w(isd:ied, jsd:jed  ,npz  ) )
-       allocate ( Atm%delz(isd:ied, jsd:jed  ,npz) )
-       if( Atm%flagstruct%hybrid_z ) then
-          allocate (  Atm%ze0(is:ie, js:je ,npz+1) )
-       else
-          allocate (  Atm%ze0(is:is, js:js  ,1) )
-       endif
-       !         allocate ( mono(isd:ied, jsd:jed, npz))
+       allocate (  Atm%ze0(is:is, js:js  ,1) )
     endif
+    !         allocate ( mono(isd:ied, jsd:jed, npz))
 
 #ifdef USE_COND
       allocate ( Atm%q_con(isd:ied,jsd:jed,1:npz) )


### PR DESCRIPTION

This fixes issue with GCC 14 with Debugging flags.

Testing with Intel shows this is zero-diff when running hydrostatic v11.

Also, as expected, in v12, GCC 14 Debug runs just fine since that is non-hydrostatic by default.

---

Testing with GCC 14 with Debugging on found a bug when running as hydrostatic:

```
Error termination. Backtrace:
At line 505 of file /discover/nobackup/mathomp4/SystemTests/builds/AGCM_GNU/CURRENT/GEOSgcm/src/Components/@GEOSgcm_GridComp/GEOSagcm_GridComp/GEOSsuperdyn_GridComp/@FVdycoreCubed_GridComp/@fvdycore/model/dyn_core.F90
Fortran runtime error: Index '2' of dimension 3 of array 'w' outside of expected range (1:1)
```

This is on the call to `c_sw`:
https://github.com/GEOS-ESM/GFDL_atmos_cubed_sphere/blob/0dd21f5426b602a698f5dfd73b44da3a62c81fe4/model/dyn_core.F90#L502-L510

The current code for allocating `w` is:
```fortran
    if ( Atm%flagstruct%hydrostatic ) then
       !Note length-one initialization if hydrostatic = .true.
       allocate (    Atm%w(isd:isd, jsd:jsd  ,1) )
       allocate ( Atm%delz(isd:isd, jsd:jsd  ,1) )
       allocate (  Atm%ze0(is:is, js:js  ,1) )
    else
       allocate (    Atm%w(isd:ied, jsd:jed  ,npz  ) )
       allocate ( Atm%delz(isd:ied, jsd:jed  ,npz) )
       if( Atm%flagstruct%hybrid_z ) then
          allocate (  Atm%ze0(is:ie, js:je ,npz+1) )
       else
          allocate (  Atm%ze0(is:is, js:js  ,1) )
       endif
       !         allocate ( mono(isd:ied, jsd:jed, npz))
    endif
```
The issue is that because I was running hydrostatic, `w` is `w(1,1,1)`. But the call to `c_sw` is `do k = 1, npz` and when it gets to the second loop, boom.

So, the simple fix is to just always allocate these arrays. It is wasteful, but solves the issue. 

NOTE 1: As I'm not sure how to test the `hybrid_z` bits of this, I've kept it as is. I suppose it should probably always be allocated as well

NOTE 2: From my reading of the current mothership fvdycore (which we have diverged from, but share a common ancestor), they could have the same issue there (see https://github.com/NOAA-GFDL/GFDL_atmos_cubed_sphere/blob/44e20a7d45ac1d2c3b84a6ffaa0c88b4cc3d5175/model/fv_arrays.F90#L1546-L1563 and https://github.com/NOAA-GFDL/GFDL_atmos_cubed_sphere/blob/44e20a7d45ac1d2c3b84a6ffaa0c88b4cc3d5175/model/dyn_core.F90#L440-L448). For that reason, I mention @bensonr as this might be seen by them if/when they test with GCC 14. (Though if they *don't* see it, I guess that says something interesting too!)