### PR TITLE
v12: Update CMake to use FMS:: targets

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -50,25 +50,23 @@ esma_add_library (${this}
 
 if (FV_PRECISION STREQUAL R4)
 elseif (FV_PRECISION STREQUAL R4R8) # FV is R4 but FMS is R8
-   get_target_property (extra_incs fms_r4 INTERFACE_INCLUDE_DIRECTORIES)
-   target_include_directories(${this} PRIVATE
-   $<BUILD_INTERFACE:${extra_incs}>
-   )
+  get_target_property (extra_incs FMS::fms_r4 INTERFACE_INCLUDE_DIRECTORIES)
+  target_include_directories(${this} PRIVATE $<BUILD_INTERFACE:${extra_incs}>)
 elseif (FV_PRECISION STREQUAL R8)
 endif ()
 
 if (FV_PRECISION STREQUAL R4)
-   target_compile_definitions (${this} PRIVATE -DSINGLE_FV -DOVERLOAD_R4)
-   target_link_libraries (${this} PUBLIC fms_r4)
+  target_compile_definitions (${this} PRIVATE -DSINGLE_FV -DOVERLOAD_R4)
+  target_link_libraries (${this} PUBLIC FMS::fms_r4)
 elseif (FV_PRECISION STREQUAL R4R8) # FV is R4 but FMS is R8
-   target_compile_definitions (${this} PRIVATE -DSINGLE_FV -DOVERLOAD_R4)
-   target_link_libraries (${this} PUBLIC fms_r8)
+  target_compile_definitions (${this} PRIVATE -DSINGLE_FV -DOVERLOAD_R4)
+  target_link_libraries (${this} PUBLIC FMS::fms_r8)
 elseif (FV_PRECISION STREQUAL R8)
-   target_link_libraries (${this} PUBLIC fms_r8)
-   string(REPLACE " " ";" tmp ${FREAL8})
-   foreach(flag ${tmp})
-     target_compile_options (${this} PRIVATE $<$<COMPILE_LANGUAGE:Fortran>:${flag}>)
-   endforeach()
+  target_link_libraries (${this} PUBLIC FMS::fms_r8)
+  string(REPLACE " " ";" tmp ${FREAL8})
+  foreach(flag ${tmp})
+    target_compile_options (${this} PRIVATE $<$<COMPILE_LANGUAGE:Fortran>:${flag}>)
+  endforeach()
 endif ()
 
 #set (CMAKE_Fortran_FLAGS_RELEASE "${GEOS_Fortran_FLAGS_VECT}")

--- a/model/mapz-driver/CMakeLists.txt
+++ b/model/mapz-driver/CMakeLists.txt
@@ -11,7 +11,7 @@ set(srcs
 
   stubs/fv_grid_utils_stub.f90
   stubs/external_ic_stub.F90
-  
+
   input/input_array_extents.f90
   input/input_scalars.f90
   input/input_arrays.f90
@@ -22,11 +22,11 @@ set(srcs
   main.F90)
 
 if (FV_PRECISION STREQUAL R4)
-  set(FMS fms_r4)
+  set(FMS FMS::fms_r4)
 elseif (FV_PRECISION STREQUAL R4R8) # FV is R4 but FMS is R8
-  set(FMS fms_r8)
+  set(FMS FMS::fms_r8)
 elseif (FV_PRECISION STREQUAL R8)
-  set(FMS fms_r8)
+  set(FMS FMS::fms_r8)
 endif ()
 
 ecbuild_add_executable(


### PR DESCRIPTION
Testing with spack showed there were still non-standard fms targets in the CMake code. This converts them all to the "correct" `FMS::` style targets.