### PR TITLE
v12: overload global_qsum to allow R8 builds

### DIFF
--- a/model/fv_grid_utils.F90
+++ b/model/fv_grid_utils.F90
@@ -1,26 +1,26 @@
 !***********************************************************************
-!*                   GNU Lesser General Public License                 
+!*                   GNU Lesser General Public License
 !*
 !* This file is part of the FV3 dynamical core.
 !*
-!* The FV3 dynamical core is free software: you can redistribute it 
+!* The FV3 dynamical core is free software: you can redistribute it
 !* and/or modify it under the terms of the
 !* GNU Lesser General Public License as published by the
-!* Free Software Foundation, either version 3 of the License, or 
+!* Free Software Foundation, either version 3 of the License, or
 !* (at your option) any later version.
 !*
-!* The FV3 dynamical core is distributed in the hope that it will be 
-!* useful, but WITHOUT ANYWARRANTY; without even the implied warranty 
-!* of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  
+!* The FV3 dynamical core is distributed in the hope that it will be
+!* useful, but WITHOUT ANYWARRANTY; without even the implied warranty
+!* of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
 !* See the GNU General Public License for more details.
 !*
 !* You should have received a copy of the GNU Lesser General Public
-!* License along with the FV3 dynamical core.  
+!* License along with the FV3 dynamical core.
 !* If not, see <http://www.gnu.org/licenses/>.
 !***********************************************************************
 
 !>@brief The module 'fv_grid_utils' contains routines for setting up and
-!! computing grid-related quantities. 
+!! computing grid-related quantities.
 !>@details Many of these are useful for computing diagnostics or setting up initial conditions.
 
  module fv_grid_utils_mod
@@ -73,7 +73,7 @@
 !   </tr>
 ! </table>
 
- 
+
 #include <fms_platform.h>
  use constants_mod,   only: omega, pi=>pi_8, cnst_radius=>radius
  use mpp_mod,         only: FATAL, mpp_error, WARNING
@@ -84,7 +84,7 @@
  use mpp_parameter_mod, only: CORNER, SCALAR_PAIR
 
  use fv_arrays_mod,   only: fv_atmos_type, fv_grid_type, fv_grid_bounds_type, &
-                            R_GRID, FVPRC, REAL4, REAL8 
+                            R_GRID, FVPRC, REAL4, REAL8
  use fv_eta_mod,      only: set_eta
  use fv_mp_mod,       only: ng, is_master
  use fv_mp_mod,       only: mp_reduce_sum, mp_reduce_min, mp_reduce_max
@@ -111,7 +111,7 @@
  logical, SAVE :: g_sum_initialized = .false.
  real(kind=R_GRID), SAVE :: global_area
 
- public f_p 
+ public f_p
  public ptop_min, big_number !CLEANUP: OK to keep since they are constants?
  public cos_angle
  public latlon2xyz, gnomonic_grids, gnomonic_grids_local, &
@@ -139,6 +139,10 @@
     module procedure g_sum_r4_, g_sum_r8_
  end interface
 
+ interface global_qsum
+    module procedure global_qsum_r4_, global_qsum_r8_
+ end interface
+
  contains
 
    subroutine grid_utils_init(Atm, npx, npy, npz, non_ortho, grid_type, c2l_order)
@@ -149,13 +153,13 @@
       integer, intent(in):: grid_type, c2l_order
 !
 ! Super (composite) grid:
- 
+
 !     9---4---8
 !     |       |
 !     1   5   3
 !     |       |
 !     6---2---7
- 
+
       real(kind=R_GRID) grid3(3,Atm%bd%isd:Atm%bd%ied+1,Atm%bd%jsd:Atm%bd%jed+1)
       real(kind=R_GRID) p1(3), p2(3), p3(3), p4(3), pp(3), ex(3), ey(3), e1(3), e2(3)
       real(kind=R_GRID) pp1(2), pp2(2), pp3(2)
@@ -362,7 +366,7 @@
            elseif (j==npy .and. .not. Atm%neststruct%nested) then
               call latlon2xyz( agrid(i,j-1,1:2), p1)
               call vect_cross(p2, p1, pp)
-           else 
+           else
               call latlon2xyz( agrid(i,j  ,1:2), p1)
               call latlon2xyz( agrid(i,j-1,1:2), p3)
               call vect_cross(p2, p3, p1)
@@ -395,11 +399,11 @@
 ! NW corner:
             cos_sg(i,j,9) = -cos_angle( grid3(1,i,j+1), grid3(1,i,j), grid3(1,i+1,j+1) )
 ! Mid-points by averaging:
-!!!         cos_sg(i,j,1) = 0.5*( cos_sg(i,j,6) + cos_sg(i,j,9) ) 
-!!!         cos_sg(i,j,2) = 0.5*( cos_sg(i,j,6) + cos_sg(i,j,7) ) 
-!!!         cos_sg(i,j,3) = 0.5*( cos_sg(i,j,7) + cos_sg(i,j,8) ) 
-!!!         cos_sg(i,j,4) = 0.5*( cos_sg(i,j,8) + cos_sg(i,j,9) ) 
-!!!!!       cos_sg(i,j,5) = 0.25*(cos_sg(i,j,6)+cos_sg(i,j,7)+cos_sg(i,j,8)+cos_sg(i,j,9)) 
+!!!         cos_sg(i,j,1) = 0.5*( cos_sg(i,j,6) + cos_sg(i,j,9) )
+!!!         cos_sg(i,j,2) = 0.5*( cos_sg(i,j,6) + cos_sg(i,j,7) )
+!!!         cos_sg(i,j,3) = 0.5*( cos_sg(i,j,7) + cos_sg(i,j,8) )
+!!!         cos_sg(i,j,4) = 0.5*( cos_sg(i,j,8) + cos_sg(i,j,9) )
+!!!!!       cos_sg(i,j,5) = 0.25*(cos_sg(i,j,6)+cos_sg(i,j,7)+cos_sg(i,j,8)+cos_sg(i,j,9))
 ! No averaging -----
             call latlon2xyz(agrid(i,j,1:2), p3)   ! righ-hand system consistent with grid3
                call mid_pt3_cart(grid3(1,i,j), grid3(1,i,j+1), p1)
@@ -430,30 +434,30 @@
       if (.not. Atm%neststruct%nested) then
       if ( sw_corner ) then
            do i=-2,0
-              sin_sg(0,i,3) = sin_sg(i,1,2) 
-              sin_sg(i,0,4) = sin_sg(1,i,1) 
+              sin_sg(0,i,3) = sin_sg(i,1,2)
+              sin_sg(i,0,4) = sin_sg(1,i,1)
            enddo
       endif
       if ( nw_corner ) then
            do i=npy,npy+2
-              sin_sg(0,i,3) = sin_sg(npy-i,npy-1,4) 
+              sin_sg(0,i,3) = sin_sg(npy-i,npy-1,4)
            enddo
            do i=-2,0
-              sin_sg(i,npy,2) = sin_sg(1,npx+i,1) 
+              sin_sg(i,npy,2) = sin_sg(1,npx+i,1)
            enddo
       endif
       if ( se_corner ) then
            do j=-2,0
-              sin_sg(npx,j,1) = sin_sg(npx-j,1,2) 
+              sin_sg(npx,j,1) = sin_sg(npx-j,1,2)
            enddo
            do i=npx,npx+2
-              sin_sg(i,0,4) = sin_sg(npx-1,npx-i,3) 
+              sin_sg(i,0,4) = sin_sg(npx-1,npx-i,3)
            enddo
       endif
       if ( ne_corner ) then
            do i=npy,npy+2
-              sin_sg(npx,i,1) = sin_sg(i,npy-1,4) 
-              sin_sg(i,npy,2) = sin_sg(npx-1,i,3) 
+              sin_sg(npx,i,1) = sin_sg(i,npy-1,4)
+              sin_sg(i,npy,2) = sin_sg(npx-1,i,3)
            enddo
         endif
      endif
@@ -495,7 +499,7 @@
      ew(1,:,:,1)=1.
      ew(2,:,:,1)=0.
      ew(3,:,:,1)=0.
-                                   
+
      ew(1,:,:,2)=0.
      ew(2,:,:,2)=1.
      ew(3,:,:,2)=0.
@@ -503,7 +507,7 @@
      es(1,:,:,1)=1.
      es(2,:,:,1)=0.
      es(3,:,:,1)=0.
-                                   
+
      es(1,:,:,2)=0.
      es(2,:,:,2)=1.
      es(3,:,:,2)=0.
@@ -579,7 +583,7 @@
             rsin_v(i,j) =  1. / max(tiny_number, sina_v(i,j)**2)
          enddo
       enddo
-     
+
       do j=jsd,jed
          do i=isd,ied
             cosa_s(i,j) = cos_sg(i,j,5)
@@ -624,8 +628,8 @@
          enddo
       enddo
 
-      !EXPLANATION HERE: calling fill_ghost overwrites **SOME** of the sin_sg 
-      !values along the outward-facing edge of a tile in the corners, which is incorrect. 
+      !EXPLANATION HERE: calling fill_ghost overwrites **SOME** of the sin_sg
+      !values along the outward-facing edge of a tile in the corners, which is incorrect.
       !What we will do is call fill_ghost and then fill in the appropriate values
 
       if (.not. Atm%neststruct%nested) then
@@ -640,28 +644,28 @@
 ! -------------------------------
       if ( sw_corner ) then
            do i=0,-2,-1
-              sin_sg(0,i,3) = sin_sg(i,1,2) 
-              sin_sg(i,0,4) = sin_sg(1,i,1) 
-              cos_sg(0,i,3) = cos_sg(i,1,2) 
-              cos_sg(i,0,4) = cos_sg(1,i,1) 
+              sin_sg(0,i,3) = sin_sg(i,1,2)
+              sin_sg(i,0,4) = sin_sg(1,i,1)
+              cos_sg(0,i,3) = cos_sg(i,1,2)
+              cos_sg(i,0,4) = cos_sg(1,i,1)
 !!!           cos_sg(0,i,7) = cos_sg(i,1,6)
 !!!           cos_sg(0,i,8) = cos_sg(i,1,7)
 !!!           cos_sg(i,0,8) = cos_sg(1,i,9)
 !!!           cos_sg(i,0,9) = cos_sg(1,i,6)
            enddo
 !!!        cos_sg(0,0,8) = 0.5*(cos_sg(0,1,7)+cos_sg(1,0,9))
-           
+
       endif
       if ( nw_corner ) then
            do i=npy,npy+2
-              sin_sg(0,i,3) = sin_sg(npy-i,npy-1,4) 
-              cos_sg(0,i,3) = cos_sg(npy-i,npy-1,4) 
+              sin_sg(0,i,3) = sin_sg(npy-i,npy-1,4)
+              cos_sg(0,i,3) = cos_sg(npy-i,npy-1,4)
 !!!           cos_sg(0,i,7) = cos_sg(npy-i,npy-1,8)
 !!!           cos_sg(0,i,8) = cos_sg(npy-i,npy-1,9)
            enddo
            do i=0,-2,-1
-              sin_sg(i,npy,2) = sin_sg(1,npy-i,1) 
-              cos_sg(i,npy,2) = cos_sg(1,npy-i,1) 
+              sin_sg(i,npy,2) = sin_sg(1,npy-i,1)
+              cos_sg(i,npy,2) = cos_sg(1,npy-i,1)
 !!!           cos_sg(i,npy,6) = cos_sg(1,npy-i,9)
 !!!           cos_sg(i,npy,7) = cos_sg(1,npy-i,6)
            enddo
@@ -669,16 +673,16 @@
       endif
       if ( se_corner ) then
            do j=0,-2,-1
-              sin_sg(npx,j,1) = sin_sg(npx-j,1,2) 
-              cos_sg(npx,j,1) = cos_sg(npx-j,1,2) 
-!!!           cos_sg(npx,j,6) = cos_sg(npx-j,1,7) 
-!!!           cos_sg(npx,j,9) = cos_sg(npx-j,1,6) 
+              sin_sg(npx,j,1) = sin_sg(npx-j,1,2)
+              cos_sg(npx,j,1) = cos_sg(npx-j,1,2)
+!!!           cos_sg(npx,j,6) = cos_sg(npx-j,1,7)
+!!!           cos_sg(npx,j,9) = cos_sg(npx-j,1,6)
            enddo
            do i=npx,npx+2
-              sin_sg(i,0,4) = sin_sg(npx-1,npx-i,3) 
-              cos_sg(i,0,4) = cos_sg(npx-1,npx-i,3) 
-!!!           cos_sg(i,0,9) = cos_sg(npx-1,npx-i,8) 
-!!!           cos_sg(i,0,8) = cos_sg(npx-1,npx-i,7) 
+              sin_sg(i,0,4) = sin_sg(npx-1,npx-i,3)
+              cos_sg(i,0,4) = cos_sg(npx-1,npx-i,3)
+!!!           cos_sg(i,0,9) = cos_sg(npx-1,npx-i,8)
+!!!           cos_sg(i,0,8) = cos_sg(npx-1,npx-i,7)
            enddo
 !!!        cos_sg(npx,0,9) = 0.5*(cos_sg(npx,1,6)+cos_sg(npx-1,0,8))
       endif
@@ -694,7 +698,7 @@
 !!!         cos_sg(npx+i,npy,7) = cos_sg(npx-1,npy+i,8)
          end do
 !!!      cos_sg(npx,npy,6) = 0.5*(cos_sg(npx-1,npy,7)+cos_sg(npx,npy-1,9))
-      endif     
+      endif
 
    else
            sina = 1.
@@ -703,9 +707,9 @@
            rsin2  = 1.
            sina_u = 1.
            sina_v = 1.
-           cosa_u = 0.        
-           cosa_v = 0.        
-           cosa_s = 0.        
+           cosa_u = 0.
+           cosa_v = 0.
+           cosa_s = 0.
            rsin_u = 1.
            rsin_v = 1.
    endif
@@ -721,12 +725,12 @@
          do j=js-1,je+1
             if ( is==1 ) then
                i=1
-               call vect_cross(ew(1,i,j,1), grid3(1,i,j+1), grid3(1,i,j)) 
+               call vect_cross(ew(1,i,j,1), grid3(1,i,j+1), grid3(1,i,j))
                call normalize_vect( ew(1,i,j,1) )
             endif
             if ( (ie+1)==npx ) then
                i=npx
-               call vect_cross(ew(1,i,j,1), grid3(1,i,j+1), grid3(1,i,j)) 
+               call vect_cross(ew(1,i,j,1), grid3(1,i,j+1), grid3(1,i,j))
                call normalize_vect( ew(1,i,j,1) )
             endif
          enddo
@@ -734,14 +738,14 @@
          if ( js==1 ) then
             j=1
             do i=is-1,ie+1
-               call vect_cross(es(1,i,j,2), grid3(1,i,j),grid3(1,i+1,j)) 
+               call vect_cross(es(1,i,j,2), grid3(1,i,j),grid3(1,i+1,j))
                call normalize_vect( es(1,i,j,2) )
             enddo
          endif
          if ( (je+1)==npy ) then
             j=npy
             do i=is-1,ie+1
-               call vect_cross(es(1,i,j,2), grid3(1,i,j),grid3(1,i+1,j)) 
+               call vect_cross(es(1,i,j,2), grid3(1,i,j),grid3(1,i+1,j))
                call normalize_vect( es(1,i,j,2) )
             enddo
          endif
@@ -758,7 +762,7 @@
      enddo
      do j=js,je
         do i=is,ie+1
-           call vect_cross(en2(1:3,i,j), grid3(1,i,j+1), grid3(1,i,j)) 
+           call vect_cross(en2(1:3,i,j), grid3(1,i,j+1), grid3(1,i,j))
            call normalize_vect( en2(1:3,i,j) )
         enddo
      enddo
@@ -766,7 +770,7 @@
 ! Make unit vectors for the coordinate extension:
 !-------------------------------------------------------------
   endif
- 
+
   do j=jsd,jed+1
      if ((j==1 .OR. j==npy) .and. .not. Atm%neststruct%nested) then
         do i=isd,ied
@@ -907,7 +911,7 @@
 
   end subroutine grid_utils_init
 
- 
+
   subroutine grid_utils_end
 ! deallocate sst_ncep (if allocated)
 #ifndef DYCORE_SOLO
@@ -916,9 +920,9 @@
 #endif
   end subroutine grid_utils_end
 
-!>@brief The subroutine 'direct_transform' performs a direct transformation of the 
+!>@brief The subroutine 'direct_transform' performs a direct transformation of the
 !! standard (symmetrical) cubic grid to a locally enhanced high-res grid on the sphere.
-!>@details It is an application of the Schmidt transformation at the south pole 
+!>@details It is an application of the Schmidt transformation at the south pole
 !! followed by a pole_shift_to_target (rotation) operation.
   subroutine direct_transform(c, i1, i2, j1, j2, lon_p, lat_p, n, lon, lat)
     real(kind=R_GRID),    intent(in):: c              !< Stretching factor
@@ -955,13 +959,13 @@
           f_p_lon = lon(i,j)
           f_p_lat = lat(i,j)
           if ( abs(c2m1) > near_zero ) then
-               sin_lat = sin(f_p_lat) 
+               sin_lat = sin(f_p_lat)
                lat_t = asin( (c2m1+c2p1*sin_lat)/(c2p1+c2m1*sin_lat) )
           else         ! no stretching
                lat_t = f_p_lat
           endif
-          sin_lat = sin(lat_t) 
-          cos_lat = cos(lat_t) 
+          sin_lat = sin(lat_t)
+          cos_lat = cos(lat_t)
             sin_o = -(sin_p*sin_lat + cos_p*cos_lat*cos(f_p_lon))
           if ( (one-abs(sin_o)) < near_zero ) then    ! poles
                f_p_lon = zero
@@ -988,7 +992,7 @@
        real(kind=R_GRID),intent(in):: v1(3), v2(3)
        real (f_p) :: vp1(3), vp2(3), prod16
        integer k
-      
+
          do k=1,3
             vp1(k) = real(v1(k),kind=f_p)
             vp2(k) = real(v2(k),kind=f_p)
@@ -1014,7 +1018,7 @@
  real(kind=R_GRID) d1, d2
  integer i, j
  integer im2, jm2
- 
+
  integer :: is,  ie,  js,  je
  integer :: isd, ied, jsd, jed
 
@@ -1212,7 +1216,7 @@
      edge_n = big_number
      edge_w = big_number
      edge_e = big_number
- 
+
 ! west edge:
 !----------------------------------------------------------
 ! p_west(j) = (1.-edge_w(j)) * p(j) + edge_w(j) * p(j-1)
@@ -1309,15 +1313,15 @@
  end subroutine gnomonic_grids
 
 !-----------------------------------------------------
-!>@brief The subroutine 'gnomonic_ed' computes the equal 
+!>@brief The subroutine 'gnomonic_ed' computes the equal
 !! distances along the 4 edges of the cubed sphere.
 !-----------------------------------------------------
-!>@details Properties: 
+!>@details Properties:
 !!  defined by intersections of great circles
 !!  max(dx,dy; global) / min(dx,dy; global) = sqrt(2) = 1.4142
 !!  Max(aspect ratio) = 1.06089
-!!  the N-S coordinate curves are const longitude on the 4 
-!!  faces with equator 
+!!  the N-S coordinate curves are const longitude on the 4
+!!  faces with equator
 !! For C2000: (dx_min, dx_max) = (3.921, 5.545) in km unit
 !! This is the grid of choice for global cloud resolving
  subroutine gnomonic_ed(im, lamda, theta)
@@ -1332,7 +1336,7 @@
  real(f_p):: rsq3, alpha, delx, dely
  integer i, j, k
 
-  rsq3 = 1.d0/sqrt(3.d0) 
+  rsq3 = 1.d0/sqrt(3.d0)
  alpha = asin( rsq3 )
 
 ! Ranges:
@@ -1407,13 +1411,13 @@
 
  end subroutine gnomonic_ed
 
-!>@brief The subroutine 'gnomonic_ed_limited' creates a limited-area 
+!>@brief The subroutine 'gnomonic_ed_limited' creates a limited-area
 !! equidistant gnomonic grid with corners given by lL (lower-left),
-!! lR (lower-right), uL (upper-left),and uR (upper-right) with im by in 
-!! cells. 
-!>@details 'lamda' and 'theta' are the latitude-longitude coordinates of 
-!! the corners of the cells. This formulation assumes the coordinates given 
-!! are on the 'prototypical equatorial panel' given by gnomonic_ed. 
+!! lR (lower-right), uL (upper-left),and uR (upper-right) with im by in
+!! cells.
+!>@details 'lamda' and 'theta' are the latitude-longitude coordinates of
+!! the corners of the cells. This formulation assumes the coordinates given
+!! are on the 'prototypical equatorial panel' given by gnomonic_ed.
 !! The resulting gnomonic limited area grid can then be translated and/or
 !! scaled to its appropriate location on another panel if desired.
  subroutine gnomonic_ed_limited(im, in, nghost, lL, lR, uL, uR, lamda, theta)
@@ -1427,8 +1431,8 @@
    real(kind=R_GRID) p1(2), p2(2)
    real(f_p):: rsq3, alpha, delx, dely
    integer i, j, k, irefl
-   
-   rsq3 = 1.d0/sqrt(3.d0) 
+
+   rsq3 = 1.d0/sqrt(3.d0)
    alpha = asin( rsq3 )
 
    lamda(1,1) = lL(1);         theta(1,1) = lL(2)
@@ -1472,7 +1476,7 @@
    end do
 
    !Get cartesian coordinates and project onto the cube face with x = -rsq3
-   
+
    i=1
    do j=1-nghost,in+1+nghost
       call latlon2xyz2(lamda(i,j), theta(i,j), pp(1,i,j))
@@ -1509,7 +1513,7 @@
         lamda(1-nghost:im+1+nghost,1-nghost:in+1+nghost), &
         theta(1-nghost:im+1+nghost,1-nghost:in+1+nghost))
    !call cart_to_latlon( (im+1)*(in+1), pp(:,1:im+1,1:in+1), lamda(1:im+1,1:in+1), theta(1:im+1,1:in+1))
-   
+
    ! Compute great-circle-distance "resolution" along the face edge:
    if ( is_master() ) then
       p1(1) = lamda(1,1);    p1(2) = theta(1,1)
@@ -1539,7 +1543,7 @@
 
  dp = 0.5d0*pi/real(im,kind=R_GRID)
 
- rsq3 = 1.d0/sqrt(3.d0) 
+ rsq3 = 1.d0/sqrt(3.d0)
  do k=1,im+1
     do j=1,im+1
        p(1,j,k) =-rsq3               ! constant
@@ -1565,9 +1569,9 @@
 
 ! Face-2
 
- rsq3 = 1.d0/sqrt(3.d0) 
+ rsq3 = 1.d0/sqrt(3.d0)
  xf = -rsq3
- y0 =  rsq3;  dy = -2.d0*rsq3/im 
+ y0 =  rsq3;  dy = -2.d0*rsq3/im
  z0 = -rsq3;  dz =  2.d0*rsq3/im
 
  do k=1,im+1
@@ -1600,7 +1604,7 @@
        ip = im + 2 - i
        avg = 0.5d0*(lamda(i,j)-lamda(ip,j))
        lamda(i, j) = avg + pi
-       lamda(ip,j) = pi - avg 
+       lamda(ip,j) = pi - avg
        avg = 0.5d0*(theta(i,j)+theta(ip,j))
        theta(i, j) = avg
        theta(ip,j) = avg
@@ -1660,7 +1664,7 @@
  end subroutine latlon2xyz
 
 !>@brief The subroutine 'mirror_xyz' computes the mirror image of p0(x0, y0, z0)
-!! as p(x, y, z) given the "mirror" as defined by p1(x1, y1, z1), p2(x2, y2, z2), 
+!! as p(x, y, z) given the "mirror" as defined by p1(x1, y1, z1), p2(x2, y2, z2),
 !! and the center of the sphere.
  subroutine mirror_xyz(p1, p2, p0, p)
 !-------------------------------------------------------------------------------
@@ -1668,7 +1672,7 @@
 !
 ! p(k) = p0(k) - 2 * [p0(k) .dot. NB(k)] * NB(k)
 !
-! where 
+! where
 !       NB(k) = p1(k) .cross. p2(k)         ---- direction of NB is imaterial
 !       the normal unit vector to the "mirror" plane
 !-------------------------------------------------------------------------------
@@ -1692,11 +1696,11 @@
     p(k) = p0(k) - 2.d0*pdot*nb(k)
  enddo
 
- end subroutine mirror_xyz 
+ end subroutine mirror_xyz
 
-!>@brief The subroutine 'mirror_latlon' computes the mirror image of 
+!>@brief The subroutine 'mirror_latlon' computes the mirror image of
 !! (lon0, lat0) as  (lon3, lat3) given the "mirror" as defined by
-!! (lon1, lat1), (lon2, lat2), and center of the sphere. 
+!! (lon1, lat1), (lon2, lat2), and center of the sphere.
  subroutine mirror_latlon(lon1, lat1, lon2, lat2, lon0, lat0, lon3, lat3)
  real(kind=R_GRID), intent(in):: lon1, lat1, lon2, lat2, lon0, lat0
  real(kind=R_GRID), intent(out):: lon3, lat3
@@ -1756,7 +1760,7 @@
      if ( lon < 0.) lon = real(2.,kind=f_p)*pi + lon
 ! RIGHT_HAND system:
      lat = asin(p(3))
-     
+
      xs(i) = lon
      ys(i) = lat
 ! q Normalized:
@@ -1767,7 +1771,7 @@
 
  end  subroutine cart_to_latlon
 
-!>@brief The subroutine 'vect_cross performs cross products 
+!>@brief The subroutine 'vect_cross performs cross products
 !! of 3D vectors: e = P1 X P2
  subroutine vect_cross(e, p1, p2)
  real(kind=R_GRID), intent(in) :: p1(3), p2(3)
@@ -1872,7 +1876,7 @@
  integer k
 
     pdot = e(1)**2 + e(2)**2 + e(3)**2
-    pdot = sqrt( pdot ) 
+    pdot = sqrt( pdot )
 
     do k=1,3
        e(k) = e(k) / pdot
@@ -1913,7 +1917,7 @@
  end subroutine intp_great_circle
 
 !>@brief The subroutine 'spherical_linear_interpolation' interpolates along the great circle connecting points p1 and p2.
-!>@details The routine uses the formula taken from <http://en.wikipedia.org/wiki/Slerp> 
+!>@details The routine uses the formula taken from <http://en.wikipedia.org/wiki/Slerp>
 !! and is attributed to Glenn Davis based on a concept by Ken Shoemake.
  subroutine spherical_linear_interpolation(beta, p1, p2, pb)
 
@@ -1924,7 +1928,7 @@
  real(kind=R_GRID):: pm(2)
  real(kind=R_GRID):: e1(3), e2(3), eb(3)
  real(kind=R_GRID):: dd, alpha, omg
- 
+
  if ( abs(p1(1) - p2(1)) < 1.d-8 .and. abs(p1(2) - p2(2)) < 1.d-8) then
     call mpp_error(WARNING, 'spherical_linear_interpolation was passed two colocated points.')
     pb = p1
@@ -1935,13 +1939,13 @@
  call latlon2xyz(p2, e2)
 
  dd = sqrt( e1(1)**2 + e1(2)**2 + e1(3)**2 )
- 
+
  e1(1) = e1(1) / dd
  e1(2) = e1(2) / dd
  e1(3) = e1(3) / dd
 
  dd = sqrt( e2(1)**2 + e2(2)**2 + e2(3)**2 )
- 
+
  e2(1) = e2(1) / dd
  e2(2) = e2(2) / dd
  e2(3) = e2(3) / dd
@@ -2029,7 +2033,7 @@
  real function great_circle_dist( q1, q2, radius )
       real(kind=R_GRID), intent(IN)           :: q1(2), q2(2)
       real(kind=R_GRID), intent(IN), optional :: radius
- 
+
       real (f_p):: p1(2), p2(2)
       real (f_p):: beta
       integer n
@@ -2050,12 +2054,12 @@
 
   end function great_circle_dist
 
-  !>@brief The function 'great_circle_dist_cart' calculates the 
-  !! normalized great circle distance between 'v1' and 'v2'.      
-  !>@date July 2006                                               
-  !>@version 0.1                                                                                                                     
+  !>@brief The function 'great_circle_dist_cart' calculates the
+  !! normalized great circle distance between 'v1' and 'v2'.
+  !>@date July 2006
+  !>@version 0.1
   function great_circle_dist_cart(v1, v2, radius)
-   
+
     real(kind=R_GRID) :: great_circle_dist_cart
     real(kind=R_GRID), dimension(3), intent(in) :: v1, v2
     real(kind=R_GRID), intent(IN), optional :: radius
@@ -2063,7 +2067,7 @@
 
     norm = (v1(1)*v1(1)+v1(2)*v1(2)+v1(3)*v1(3))                  &
                 *(v2(1)*v2(1)+v2(2)*v2(2)+v2(3)*v2(3))
-    
+
     !if (norm <= 0.) print*, 'negative norm: ', norm, v1, v2
 
     great_circle_dist_cart=(v1(1)*v2(1)+v1(2)*v2(2)+v1(3)*v2(3))                  &
@@ -2077,18 +2081,18 @@
 
 
   end function great_circle_dist_cart
-                                                                                                           
- !>@brief The subroutine 'intersect' calculates the intersection of two great circles.       
- !>@details input:                                                           
- !> a1, a2,  -   pairs of points on sphere in cartesian coordinates  
- !> b1, b2       defining great circles                              
- !> radius   -   radius of the sphere                                                                                                
- !> output:                                                          
- !> x_inter  -   nearest intersection point of the great circles     
- !> local_a  -   true if x1 between (a1, a2)                         
- !> local_b  -   true if x1 between (b1, b2)                                        
- !>@date July 2006                                                 
- !>@version: 0.1        
+
+ !>@brief The subroutine 'intersect' calculates the intersection of two great circles.
+ !>@details input:
+ !> a1, a2,  -   pairs of points on sphere in cartesian coordinates
+ !> b1, b2       defining great circles
+ !> radius   -   radius of the sphere
+ !> output:
+ !> x_inter  -   nearest intersection point of the great circles
+ !> local_a  -   true if x1 between (a1, a2)
+ !> local_b  -   true if x1 between (b1, b2)
+ !>@date July 2006
+ !>@version: 0.1
  subroutine intersect(a1,a2,b1,b2,radius,x_inter,local_a,local_b)
 
     real(kind=R_GRID), dimension(3), intent(in)  :: a1, a2, b1, b2
@@ -2155,7 +2159,7 @@
 
       dx(:)=x1(:)-x2(:)
       dist=dx(1)*dx(1)+dx(2)*dx(2)+dx(3)*dx(3)
-    
+
       dx(:)=x1(:)-x_inter(:)
       dist1=dx(1)*dx(1)+dx(2)*dx(2)+dx(3)*dx(3)
       dx(:)=x2(:)-x_inter(:)
@@ -2166,23 +2170,23 @@
       else
          local=.false.
       endif
-      
+
     end subroutine check_local
     !------------------------------------------------------------------!
   end subroutine intersect
- 
- !>@brief The subroutine 'intersect_cross' calculates the intersection of two great circles.       
- !>@details input:                                                           
- !> a1, a2,  -   pairs of points on sphere in cartesian coordinates  
- !> b1, b2       defining great circles                              
- !> radius   -   radius of the sphere                                
- !>                                                                  
- !> output:                                                          
- !> x_inter  -   nearest intersection point of the great circles     
- !> local_a  -   true if x1 between (a1, a2)                         
- !> local_b  -   true if x1 between (b1, b2)     
+
+ !>@brief The subroutine 'intersect_cross' calculates the intersection of two great circles.
+ !>@details input:
+ !> a1, a2,  -   pairs of points on sphere in cartesian coordinates
+ !> b1, b2       defining great circles
+ !> radius   -   radius of the sphere
+ !>
+ !> output:
+ !> x_inter  -   nearest intersection point of the great circles
+ !> local_a  -   true if x1 between (a1, a2)
+ !> local_b  -   true if x1 between (b1, b2)
  subroutine intersect_cross(a1,a2,b1,b2,radius,x_inter,local_a,local_b)
-  
+
     real(kind=R_GRID), dimension(3), intent(in)  :: a1, a2, b1, b2
     real(kind=R_GRID), intent(in) :: radius
     real(kind=R_GRID), dimension(3), intent(out) :: x_inter
@@ -2194,7 +2198,7 @@
     !! vector v1, which is the cross product of any two vectors lying
     !! in the plane; here, we use position vectors, which are unit
     !! vectors lying in the plane and rooted at the center of the
-    !! sphere. 
+    !! sphere.
     !> The intersection of two great circles is where the the
     !! intersection of the planes, a line, itself intersects the
     !! sphere. Since the planes are defined by perpendicular vectors
@@ -2212,7 +2216,7 @@
     !Normalize
     x_inter = x_inter/sqrt(x_inter(1)**2 + x_inter(2)**2 + x_inter(3)**2)
 
-    ! check if intersection is between pairs of points on sphere 
+    ! check if intersection is between pairs of points on sphere
     call get_nearest()
     call check_local(a1,a2,local_a)
     call check_local(b1,b2,local_b)
@@ -2241,7 +2245,7 @@
 
       dx(:)=x1(:)-x2(:)
       dist=dx(1)*dx(1)+dx(2)*dx(2)+dx(3)*dx(3)
-    
+
       dx(:)=x1(:)-x_inter(:)
       dist1=dx(1)*dx(1)+dx(2)*dx(2)+dx(3)*dx(3)
       dx(:)=x2(:)-x_inter(:)
@@ -2252,7 +2256,7 @@
       else
          local=.false.
       endif
-      
+
     end subroutine check_local
     !------------------------------------------------------------------!
   end subroutine intersect_cross
@@ -2360,7 +2364,7 @@
 
 
  subroutine cubed_to_latlon(u, v, ua, va, gridstruct, npx, npy, km, mode, grid_type, domain, nested, c2l_ord, bd)
- type(fv_grid_bounds_type), intent(IN) :: bd 
+ type(fv_grid_bounds_type), intent(IN) :: bd
  integer, intent(in) :: km, npx, npy, grid_type, c2l_ord
  integer, intent(in) :: mode   ! update if present
  type(fv_grid_type), intent(IN) :: gridstruct
@@ -2392,7 +2396,7 @@
   real, intent(out)::  va(bd%isd:bd%ied, bd%jsd:bd%jed,km)
   type(domain2d), intent(INOUT) :: domain
   logical, intent(IN) :: nested
-! Local 
+! Local
 ! 4-pt Lagrange interpolation
   real :: a1 =  0.5625
   real :: a2 = -0.0625
@@ -2531,7 +2535,7 @@
   real, intent(out):: ua(bd%isd:bd%ied, bd%jsd:bd%jed,km)
   real, intent(out):: va(bd%isd:bd%ied, bd%jsd:bd%jed,km)
 !--------------------------------------------------------------
-! Local 
+! Local
   real wu(bd%is-1:bd%ie+1,  bd%js-1:bd%je+2)
   real wv(bd%is-1:bd%ie+2,  bd%js-1:bd%je+1)
   real u1(bd%is-1:bd%ie+1), v1(bd%is-1:bd%ie+1)
@@ -2639,12 +2643,12 @@
          ec(k) = ec(k) / dd   ! cell center position
       enddo
 
-! Perform the "extrapolation" in 3D (x-y-z) 
+! Perform the "extrapolation" in 3D (x-y-z)
       do k=1,3
-         qq1(k) = ec(k) + fac*(p1(k)-ec(k)) 
-         qq2(k) = ec(k) + fac*(p2(k)-ec(k)) 
-         qq3(k) = ec(k) + fac*(p3(k)-ec(k)) 
-         qq4(k) = ec(k) + fac*(p4(k)-ec(k)) 
+         qq1(k) = ec(k) + fac*(p1(k)-ec(k))
+         qq2(k) = ec(k) + fac*(p2(k)-ec(k))
+         qq3(k) = ec(k) + fac*(p3(k)-ec(k))
+         qq4(k) = ec(k) + fac*(p4(k)-ec(k))
       enddo
 
 !--------------------------------------------------------
@@ -2764,12 +2768,12 @@
 
  end function get_area
 
-  !>@brief The function 'dist2side' calculates the shortest normalized distance 
-  !! on a sphere from point to straight line defined by 'v1' and 'v2'.  
+  !>@brief The function 'dist2side' calculates the shortest normalized distance
+  !! on a sphere from point to straight line defined by 'v1' and 'v2'.
   !>@details This version uses cartesian coordinates.
-  !>@date Feb 2007                                                
-  !>@version 0.1    
-  function dist2side(v1, v2, point)  
+  !>@date Feb 2007
+  !>@version 0.1
+  function dist2side(v1, v2, point)
     real(kind=R_GRID) :: dist2side
     real(kind=R_GRID), dimension(3), intent(in) :: v1, v2, point
 
@@ -2781,7 +2785,7 @@
 
   end function dist2side
 
-  !>@brief The function 'dist2side_latlon' is the version of 'dist2side' that 
+  !>@brief The function 'dist2side_latlon' is the version of 'dist2side' that
   !! takes points in latitude-longitude coordinates.
   function dist2side_latlon(v1,v2,point)
 
@@ -2809,7 +2813,7 @@
 
 
  real(kind=R_GRID) function spherical_angle(p1, p2, p3)
- 
+
 !           p3
 !         /
 !        /
@@ -2836,13 +2840,13 @@
 ! Page 41, Silverman's book on Vector Algebra; spherical trigonmetry
 !-------------------------------------------------------------------
 ! Vector P:
-   px = e1(2)*e2(3) - e1(3)*e2(2) 
-   py = e1(3)*e2(1) - e1(1)*e2(3) 
-   pz = e1(1)*e2(2) - e1(2)*e2(1) 
+   px = e1(2)*e2(3) - e1(3)*e2(2)
+   py = e1(3)*e2(1) - e1(1)*e2(3)
+   pz = e1(1)*e2(2) - e1(2)*e2(1)
 ! Vector Q:
-   qx = e1(2)*e3(3) - e1(3)*e3(2) 
-   qy = e1(3)*e3(1) - e1(1)*e3(3) 
-   qz = e1(1)*e3(2) - e1(2)*e3(1) 
+   qx = e1(2)*e3(3) - e1(3)*e3(2)
+   qy = e1(3)*e3(1) - e1(1)*e3(3)
+   qz = e1(1)*e3(2) - e1(2)*e3(1)
 
    ddd = (px*px+py*py+pz*pz)*(qx*qx+qy*qy+qz*qz)
 
@@ -2856,7 +2860,7 @@
            if (ddd < 0.d0) then
               angle = 4.d0*atan(1.0d0) !should be pi
            else
-              angle = 0.d0 
+              angle = 0.d0
            end if
         else
              angle = acos( ddd )
@@ -2871,9 +2875,9 @@
  real(kind=R_GRID) function cos_angle(p1, p2, p3)
 ! As spherical_angle, but returns the cos(angle)
 !       p3
-!       ^  
-!       |  
-!       | 
+!       ^
+!       |
+!       |
 !       p1 ---> p2
 !
  real(kind=R_GRID), intent(in):: p1(3), p2(3), p3(3)
@@ -2894,19 +2898,19 @@
 ! Page 41, Silverman's book on Vector Algebra; spherical trigonmetry
 !-------------------------------------------------------------------
 ! Vector P:= e1 X e2
-   px = e1(2)*e2(3) - e1(3)*e2(2) 
-   py = e1(3)*e2(1) - e1(1)*e2(3) 
-   pz = e1(1)*e2(2) - e1(2)*e2(1) 
+   px = e1(2)*e2(3) - e1(3)*e2(2)
+   py = e1(3)*e2(1) - e1(1)*e2(3)
+   pz = e1(1)*e2(2) - e1(2)*e2(1)
 
 ! Vector Q: e1 X e3
-   qx = e1(2)*e3(3) - e1(3)*e3(2) 
-   qy = e1(3)*e3(1) - e1(1)*e3(3) 
-   qz = e1(1)*e3(2) - e1(2)*e3(1) 
+   qx = e1(2)*e3(3) - e1(3)*e3(2)
+   qy = e1(3)*e3(1) - e1(1)*e3(3)
+   qz = e1(1)*e3(2) - e1(2)*e3(1)
 
 ! ddd = sqrt[ (P*P) (Q*Q) ]
    ddd = sqrt( (px**2+py**2+pz**2)*(qx**2+qy**2+qz**2) )
    if ( ddd > 0.d0 ) then
-        angle = (px*qx+py*qy+pz*qz) / ddd 
+        angle = (px*qx+py*qy+pz*qz) / ddd
    else
         angle = 1.d0
    endif
@@ -2914,7 +2918,7 @@
 
  end function cos_angle
 
- !>@brief The function 'g_sum_r4_' is the fast version of 'globalsum'. 
+ !>@brief The function 'g_sum_r4_' is the fast version of 'globalsum'.
  real(kind=REAL4) function g_sum_r4_(domain, p, ifirst, ilast, jfirst, jlast, ngc, area, mode, reproduce, quicksum)
       integer, intent(IN) :: ifirst, ilast
       integer, intent(IN) :: jfirst, jlast, ngc
@@ -2927,7 +2931,7 @@
       real(kind=REAL4) :: gsum
       integer :: err
       integer :: sflag
-       
+
       sflag = NON_BITWISE_EXACT_SUM
       if(present(reproduce)) then
         if (reproduce==0) sflag = NON_BITWISE_EXACT_SUM
@@ -2940,12 +2944,12 @@
          if ( is_master() ) write(*,*) 'Global Area=',global_area
          g_sum_initialized = .true.
       end if
- 
+
       if ( present(quicksum) ) then
 !-------------------------
 ! Quick local sum algorithm
 !-------------------------
-         gsum = global_qsum(p(:,:)*real(area(ifirst:ilast,jfirst:jlast),kind=REAL4), ifirst, ilast, jfirst, jlast)
+         gsum = global_qsum_r4_(p(:,:)*real(area(ifirst:ilast,jfirst:jlast),kind=REAL4), ifirst, ilast, jfirst, jlast)
       else
 !-------------------------
 ! FMS global sum algorithm:
@@ -2961,7 +2965,7 @@
       endif
  end function g_sum_r4_
 
- !>@brief The function 'g_sum_r8_' is the fast version of 'globalsum'. 
+ !>@brief The function 'g_sum_r8_' is the fast version of 'globalsum'.
  real(kind=REAL8) function g_sum_r8_(domain, p, ifirst, ilast, jfirst, jlast, ngc, area, mode, reproduce, quicksum)
       integer, intent(IN) :: ifirst, ilast
       integer, intent(IN) :: jfirst, jlast, ngc
@@ -2987,15 +2991,15 @@
          if ( is_master() ) write(*,*) 'Global Area=',global_area
          g_sum_initialized = .true.
       end if
- 
+
       if ( present(quicksum) ) then
 !-------------------------
 ! Quick local sum algorithm
 !-------------------------
-         gsum = global_qsum_r8(p(:,:)*area(ifirst:ilast,jfirst:jlast), ifirst, ilast, jfirst, jlast)
+         gsum = global_qsum_r8_(p(:,:)*area(ifirst:ilast,jfirst:jlast), ifirst, ilast, jfirst, jlast)
       else
 !-------------------------
-! FMS global sum algorithm: 
+! FMS global sum algorithm:
 !-------------------------
          gsum = mpp_global_sum(domain, p(:,:)*area(ifirst:ilast,jfirst:jlast), flags=sflag)
       endif
@@ -3008,31 +3012,12 @@
  end function g_sum_r8_
 
 !>@brief The function 'global_qsum' computes the quick global sum without area weighting.
- real function global_qsum(p, ifirst, ilast, jfirst, jlast)
+ real(kind=REAL4) function global_qsum_r4_(p, ifirst, ilast, jfirst, jlast)
       integer, intent(IN) :: ifirst, ilast
       integer, intent(IN) :: jfirst, jlast
-      real, intent(IN) :: p(ifirst:ilast,jfirst:jlast) !< field to be summed
+      real(kind=REAL4), intent(IN) :: p(ifirst:ilast,jfirst:jlast) !< field to be summed
       integer :: i,j
-      real gsum
-         
-      gsum = 0.
-      do j=jfirst,jlast
-         do i=ifirst,ilast
-            gsum = gsum + p(i,j)
-         enddo
-      enddo
-      call mp_reduce_sum(gsum)
-
-      global_qsum  = gsum
-
- end function global_qsum
-
- real(kind=8) function global_qsum_r8(p, ifirst, ilast, jfirst, jlast)
-      integer, intent(IN) :: ifirst, ilast
-      integer, intent(IN) :: jfirst, jlast
-      real(kind=8), intent(IN) :: p(ifirst:ilast,jfirst:jlast) !< field to be summed
-      integer :: i,j
-      real(kind=8) gsum
+      real(kind=REAL4) gsum
 
       gsum = 0.
       do j=jfirst,jlast
@@ -3042,9 +3027,28 @@
       enddo
       call mp_reduce_sum(gsum)
 
-      global_qsum_r8  = gsum
+      global_qsum_r4_  = gsum
 
- end function global_qsum_r8
+ end function global_qsum_r4_
+
+ real(kind=REAL8) function global_qsum_r8_(p, ifirst, ilast, jfirst, jlast)
+      integer, intent(IN) :: ifirst, ilast
+      integer, intent(IN) :: jfirst, jlast
+      real(kind=REAL8), intent(IN) :: p(ifirst:ilast,jfirst:jlast) !< field to be summed
+      integer :: i,j
+      real(kind=REAL8) gsum
+
+      gsum = 0.
+      do j=jfirst,jlast
+         do i=ifirst,ilast
+            gsum = gsum + p(i,j)
+         enddo
+      enddo
+      call mp_reduce_sum(gsum)
+
+      global_qsum_r8_  = gsum
+
+ end function global_qsum_r8_
 
 
  subroutine global_mx(q, n_g, qmin, qmax, bd)
@@ -3116,7 +3120,7 @@
   ied = bd%ied
   jsd = bd%jsd
   jed = bd%jed
- 
+
      do j=jsd,jed
         do i=isd,ied
            if ( (i<1 .and. j<1) ) then
@@ -3156,7 +3160,7 @@
   ied = bd%ied
   jsd = bd%jsd
   jed = bd%jed
-  
+
      do j=jsd,jed
         do i=isd,ied
            if ( (i<1 .and. j<1) ) then
@@ -3216,7 +3220,7 @@
      ptop = ph(1)
      do j=js-1,je+1
         do i=is-1,ie+1
-           pe(i,1,j) = ptop 
+           pe(i,1,j) = ptop
         enddo
      enddo
 
@@ -3252,7 +3256,7 @@
   real(kind=R_GRID), intent (out), dimension (n,n):: x   !< inverted maxtrix
   real(kind=R_GRID), dimension (n,n) :: b
   integer indx(n)
- 
+
   do i = 1, n
      do j = 1, n
         b(i,j) = 0.0
@@ -3262,9 +3266,9 @@
   do i = 1, n
      b(i,i) = 1.0
   end do
- 
+
   call elgs (a,n,indx)
- 
+
   do i = 1, n-1
      do j = i+1, n
         do k = 1, n
@@ -3272,7 +3276,7 @@
         end do
      end do
   end do
- 
+
   do i = 1, n
      x(n,i) = b(indx(n),i)/a(indx(n),n)
      do j = n-1, 1, -1
@@ -3285,7 +3289,7 @@
   end do
 
  end subroutine invert_matrix
- 
+
 !>@brief The subroutine 'elgs' performs the partial-pivoting gaussian elimination.
 !>@details a(n,n) is the original matrix in the input and transformed matrix
 !! plus the pivoting element ratios below the diagonal in the output.
@@ -3297,7 +3301,7 @@
 !
   real(kind=R_GRID) :: c1, pie, pi1, pj
   real(kind=R_GRID), dimension (n) :: c
- 
+
   do i = 1, n
      indx(i) = i
   end do
@@ -3343,7 +3347,7 @@
        end do
      end do
   end do
- 
+
  end subroutine elgs
 
  subroutine get_latlon_vector(pp, elon, elat)
@@ -3362,8 +3366,8 @@
 
  end subroutine get_latlon_vector
 
- 
-  
+
+
 
  subroutine project_sphere_v( np, f, e )
 !---------------------------------
@@ -3489,7 +3493,7 @@
      real(R_GRID) :: b(1:im+1)
      integer i, j
 
-     rsq3 = 1./sqrt(3.) 
+     rsq3 = 1./sqrt(3.)
      alpha = asin( rsq3 )
      dely = alpha / im
 
@@ -3533,7 +3537,7 @@
      integer i,j
 
      dp = (pi/4) /real(im,R_GRID)
-     rsq3 = 1./sqrt(3.) 
+     rsq3 = 1./sqrt(3.)
      do j = lbound(lambda,2), ubound(lambda,2)
         do i = lbound(lambda,1), ubound(lambda,1)
            p(1,i,j) =-rsq3               ! constant
@@ -3564,7 +3568,7 @@
 
      ! Face-2
 
-     rsq3 = 1./sqrt(3.) 
+     rsq3 = 1./sqrt(3.)
      xf = -rsq3
      dx = rsq3/im
 
@@ -3583,37 +3587,37 @@
      ! vector version of cart_to_latlon1
      real(R_GRID), intent(inout) :: q(:,:,:)
      real(R_GRID), intent(inout) :: xs(:,:), ys(:,:)
-     
+
      ! local
      real(R_GRID), parameter:: esl=1.e-10
      real(R_GRID) :: p(3)
      real(R_GRID) :: dist, lat, lon
      integer i, j, k
-     
-     
+
+
      do j = 1, size(q,3)
         do i = 1, size(q,2)
            p = q(:,i,j)
-           
+
            dist = sqrt(p(1)**2 + p(2)**2 + p(3)**2)
            p = p/dist
-           
+
            if ( (abs(p(1))+abs(p(2)))  < esl ) then
               lon = 0.
            else
               lon = atan2( p(2), p(1) )   ! range [-pi,pi]
            endif
-           
+
            if ( lon < 0.) lon = 2.*pi + lon
            lat = asin(p(3))
-           
+
            xs(i,j) = lon
            ys(i,j) = lat
            ! q Normalized:
            q(:,i,j) = p
         enddo
      end do
-     
+
   end  subroutine cart_to_latlon_new
 
  end module fv_grid_utils_mod


### PR DESCRIPTION
Companion to https://github.com/GEOS-ESM/FVdycoreCubed_GridComp/pull/293

---

When building FV as R8 precision, the build failed. This was because `global_qsum` was declared as:
```fortran
 real function global_qsum(p, ifirst, ilast, jfirst, jlast)
      integer, intent(IN) :: ifirst, ilast
      integer, intent(IN) :: jfirst, jlast
      real, intent(IN) :: p(ifirst:ilast,jfirst:jlast) !< field to be summed
      integer :: i,j
      real gsum
```
But when we build as R8, `real` is actually `REAL64` aka `REAL8` but this line:
```fortran
         gsum = global_qsum(p(:,:)*real(area(ifirst:ilast,jfirst:jlast),kind=REAL4), ifirst, ilast, jfirst, jlast)
```
is sending `p` (which is `REAL4`) and an explicit `REAL4` to `global_qsum` which is expecting `REAL8`.

So we correctly make an r4 and r8 version.