### PR TITLE
v11: Updates needed for Ninja support

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -50,26 +50,25 @@ esma_add_library (${this}
   DEPENDENCIES MAPL GFTL_SHARED::gftl-shared esmf)
 
 if (FV_PRECISION STREQUAL R4)
+  target_link_libraries (${this} PUBLIC fms_r4)
+  target_compile_definitions (${this} PRIVATE SINGLE_FV OVERLOAD_R4)
 elseif (FV_PRECISION STREQUAL R4R8) # FV is R4 but FMS is R8
-   get_target_property (extra_incs fms_r4 INTERFACE_INCLUDE_DIRECTORIES)
-   target_include_directories(${this} PRIVATE
-   $<BUILD_INTERFACE:${extra_incs}>
-   )
-elseif (FV_PRECISION STREQUAL R8)
-endif ()
+  # fvdycore needs r4 .mod interfaces
+  get_target_property(inc_r4 fms_r4 INTERFACE_INCLUDE_DIRECTORIES)
+  target_include_directories(${this} PRIVATE $<BUILD_INTERFACE:${inc_r4}>)
 
-if (FV_PRECISION STREQUAL R4)
-   target_compile_definitions (${this} PRIVATE -DSINGLE_FV -DOVERLOAD_R4)
-   target_link_libraries (${this} PUBLIC fms_r4)
-elseif (FV_PRECISION STREQUAL R4R8) # FV is R4 but FMS is R8
-   target_compile_definitions (${this} PRIVATE -DSINGLE_FV -DOVERLOAD_R4)
-   target_link_libraries (${this} PUBLIC fms_r8)
+  # But fvdycore should not *compile* with fms_r8 includes
+  target_link_libraries(${this} PUBLIC $<LINK_ONLY:fms_r8>)
+
+  target_compile_definitions (${this} PRIVATE SINGLE_FV OVERLOAD_R4)
+
+  add_dependencies(${this} fms_r4 fms_r8)
 elseif (FV_PRECISION STREQUAL R8)
-   target_link_libraries (${this} PUBLIC fms_r8)
-   string(REPLACE " " ";" tmp ${FREAL8})
-   foreach(flag ${tmp})
-     target_compile_options (${this} PRIVATE $<$<COMPILE_LANGUAGE:Fortran>:${flag}>)
-   endforeach()
+  target_link_libraries (${this} PUBLIC fms_r8)
+  string(REPLACE " " ";" tmp ${FREAL8})
+  foreach(flag ${tmp})
+    target_compile_options (${this} PRIVATE $<$<COMPILE_LANGUAGE:Fortran>:${flag}>)
+  endforeach()
 endif ()
 
 #set (CMAKE_Fortran_FLAGS_RELEASE "${GEOS_Fortran_FLAGS_VECT}")


### PR DESCRIPTION
This PR has CMake updates needed for Ninja support. 

The main issue is that Ninja seems a bit stricter in how it's handling our fms r4/r8 nonsense (that is removed in #112). This CMake update allows Ninja to build.