### PR TITLE
v12: Updates needed for Ninja support

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -50,7 +50,7 @@ esma_add_library (${this}
 
 if (FV_PRECISION STREQUAL R4)
   target_link_libraries (${this} PUBLIC FMS::fms_r4)
-  target_compile_definitions (${this} PRIVATE SINGLE_FV OVERLOAD_R4
+  target_compile_definitions (${this} PRIVATE SINGLE_FV OVERLOAD_R4)
 elseif (FV_PRECISION STREQUAL R4R8) # FV is R4 but FMS is R8
   # fvdycore needs r4 .mod interfaces
   get_target_property(inc_r4 FMS::fms_r4 INTERFACE_INCLUDE_DIRECTORIES)

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -49,18 +49,19 @@ esma_add_library (${this}
   DEPENDENCIES MAPL GFTL_SHARED::gftl-shared esmf)
 
 if (FV_PRECISION STREQUAL R4)
-elseif (FV_PRECISION STREQUAL R4R8) # FV is R4 but FMS is R8
-  get_target_property (extra_incs FMS::fms_r4 INTERFACE_INCLUDE_DIRECTORIES)
-  target_include_directories(${this} PRIVATE $<BUILD_INTERFACE:${extra_incs}>)
-elseif (FV_PRECISION STREQUAL R8)
-endif ()
-
-if (FV_PRECISION STREQUAL R4)
-  target_compile_definitions (${this} PRIVATE -DSINGLE_FV -DOVERLOAD_R4)
   target_link_libraries (${this} PUBLIC FMS::fms_r4)
+  target_compile_definitions (${this} PRIVATE SINGLE_FV OVERLOAD_R4
 elseif (FV_PRECISION STREQUAL R4R8) # FV is R4 but FMS is R8
-  target_compile_definitions (${this} PRIVATE -DSINGLE_FV -DOVERLOAD_R4)
-  target_link_libraries (${this} PUBLIC FMS::fms_r8)
+  # fvdycore needs r4 .mod interfaces
+  get_target_property(inc_r4 FMS::fms_r4 INTERFACE_INCLUDE_DIRECTORIES)
+  target_include_directories(${this} PRIVATE $<BUILD_INTERFACE:${inc_r4}>)
+
+  # But fvdycore should not *compile* with FMS::fms_r8 includes
+  target_link_libraries(${this} PUBLIC $<LINK_ONLY:FMS::fms_r8>)
+
+  target_compile_definitions (${this} PRIVATE SINGLE_FV OVERLOAD_R4)
+
+  add_dependencies(${this} FMS::fms_r4 FMS::fms_r8)
 elseif (FV_PRECISION STREQUAL R8)
   target_link_libraries (${this} PUBLIC FMS::fms_r8)
   string(REPLACE " " ";" tmp ${FREAL8})


### PR DESCRIPTION
This PR has CMake updates needed for Ninja support.

The main issue is that Ninja seems a bit stricter in how it's handling our fms r4/r8 nonsense (that is removed in https://github.com/GEOS-ESM/GFDL_atmos_cubed_sphere/pull/112). This CMake update allows Ninja to build.