### PR TITLE
v12: Initialize q_con to fix ifx

### DIFF
--- a/model/fv_arrays.F90
+++ b/model/fv_arrays.F90
@@ -886,7 +886,7 @@ module fv_arrays_mod
                                 !<     1: GMAO linear
                                 !<     2: GMAO quadratic
                                 !<     3: GMAO cubic
- 
+
    logical :: gmao_top_bc = .false.  !< Optional upper BC in remapping of T or TE from GMAO (true or false)
 
    logical :: gmao_bot_bc = .false.  !< Optional lower BC in remapping of T or TE from GMAO (true or false)
@@ -1527,6 +1527,7 @@ contains
 #else
       allocate ( Atm%q_con(isd:isd,jsd:jsd,1) )
 #endif
+      Atm%q_con = 0.
 
 #ifndef NO_TOUCH_MEM
 ! Notes by SJL


### PR DESCRIPTION
In testing with `ifx` and debug flags, it was found that the compiler was crashing in fv:
```
forrtl: error (65): floating invalid
Image              PC                Routine            Line        Source
libpthread-2.31.s  000014C8C6A2F910  Unknown               Unknown  Unknown
GEOSgcm.x          00000000090C7D12  nh_utils_mod_mp_r         377  nh_utils.F90
libiomp5.so        000014C8DE14FDC9  __kmp_invoke_micr     Unknown  Unknown
libiomp5.so        000014C8DE0CA03B  __kmp_fork_call       Unknown  Unknown
libiomp5.so        000014C8DE08BE00  __kmpc_fork_call      Unknown  Unknown
GEOSgcm.x          0000000008FFDD18  riem_solver_c             353  nh_utils.F90
GEOSgcm.x          0000000008DA561C  dyn_core                  583  dyn_core.F90
GEOSgcm.x          00000000087D9822  fv_dynamics               645  fv_dynamics.F90
GEOSgcm.x          00000000074F37AD  fv_run                   1980  FV_StateMod.F90
GEOSgcm.x          0000000007261728  run                      4451  DynCore_GridCompMod.F90
...
```

Looking into it, the issue was that `q_con` was NaN at that line in `nh_utils.F90`. So, the simplest fix was tried: initialize `q_con` to zero on allocation.

And it seems to work! This seems to fix the issue with `ifx` and tests with `ifort` shows it to be zero-diff.

I guess `ifx` is a bit stricter with debug flags? Not sure. Usually GNU would have seen this too...