### PR TITLE
Replace 'use MAPL' with 'use MAPL2' and update CMake deps for MAPL→MAPL2→MAPL3 rename

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -46,7 +46,7 @@ set (srcs
 
 esma_add_library (${this}
   SRCS ${srcs}
-  DEPENDENCIES MAPL GFTL_SHARED::gftl-shared-v2 esmf)
+  DEPENDENCIES MAPL2 MAPL GFTL_SHARED::gftl-shared-v2 esmf)
 
 if (FV_PRECISION STREQUAL R4)
   target_link_libraries (${this} PUBLIC FMS::fms_r4)

--- a/tools/external_ic.F90
+++ b/tools/external_ic.F90
@@ -18,7 +18,7 @@ module external_ic_mod
 
    use constants_mod,     only: pi=>pi_8, omega, grav, kappa, rdgas, rvgas, cp_air
 #ifdef MAPL_MODE
-   use MAPL
+   use MAPL2
 #endif
    use, intrinsic :: iso_fortran_env, only: REAL64, REAL32
 


### PR DESCRIPTION
## Summary

- Replaces `use MAPL` with `use MAPL2` in `tools/external_ic.F90`
- Adds `MAPL2` to CMake `DEPENDENCIES` in `CMakeLists.txt`

These changes support the transitional MAPL→MAPL2→MAPL3 rename being coordinated across GEOS-ESM repos.

## References

- Closes #118
- Part of the broader `geos/release/MAPL-v3` / MAPL #4600 rename effort