### PR TITLE
Migrate external_ic.F90 from use MAPL2 to use MAPL (fixes #122)

### DIFF
--- a/tools/external_ic.F90
+++ b/tools/external_ic.F90
@@ -18,7 +18,7 @@ module external_ic_mod
 
    use constants_mod,     only: pi=>pi_8, omega, grav, kappa, rdgas, rvgas, cp_air
 #ifdef MAPL_MODE
-   use MAPL2
+   use MAPL
 #endif
    use, intrinsic :: iso_fortran_env, only: REAL64, REAL32
 


### PR DESCRIPTION
## Summary

- Replaces `use MAPL2` with `use MAPL` in `tools/external_ic.F90`
- No logic changes — use statement migration only

## Dependency

Requires GEOS-ESM/MAPL#4882 (merged) which re-exports the needed symbols through the `MAPL` umbrella module.