### PR TITLE
Remove MAPL2 from CMakeLists dependencies

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -46,7 +46,7 @@ set (srcs
 
 esma_add_library (${this}
   SRCS ${srcs}
-  DEPENDENCIES MAPL2 MAPL GFTL_SHARED::gftl-shared-v2 esmf)
+  DEPENDENCIES MAPL GFTL_SHARED::gftl-shared-v2 esmf)
 
 if (FV_PRECISION STREQUAL R4)
   target_link_libraries (${this} PUBLIC FMS::fms_r4)


### PR DESCRIPTION
## Summary

- Removes `MAPL2` from `DEPENDENCIES` in `CMakeLists.txt`

## Motivation

Part of the MAPL2 retirement sequence. Contingent on GEOS-ESM/MAPL#4889 (PR1) being merged.

## Related Issues

Closes #124